### PR TITLE
Use AZ Rest to avoid the custom token retrieval

### DIFF
--- a/cleanup.ps1
+++ b/cleanup.ps1
@@ -10,4 +10,4 @@ param (
 $credentials = $azureCredentials | ConvertFrom-Json
 $subscriptionId = $credentials.subscriptionId
 az rest --method DELETE `
-     --uri https://management.azure.com/subscriptions/$subscriptionId/resourceGroups/GitHubActions-RG/providers/Microsoft.DocumentDB/databaseAccounts/$cosmosName?api-version=2021-04-15
+     --uri https://management.azure.com/subscriptions/$subscriptionId/resourceGroups/GitHubActions-RG/providers/Microsoft.DocumentDB/databaseAccounts/${cosmosName}?api-version=2021-04-15

--- a/cleanup.ps1
+++ b/cleanup.ps1
@@ -7,4 +7,7 @@ param (
 #$ignore = az cosmosdb delete --resource-group GitHubActions-RG --name $cosmosName --yes
 
 # az rest method
-az rest --method DELETE --uri "https://management.azure.com/subscriptions/$($credentials.subscriptionId)/resourceGroups/GitHubActions-RG/providers/Microsoft.DocumentDB/databaseAccounts/$($cosmosName)?api-version=2021-04-15"
+$credentials = $azureCredentials | ConvertFrom-Json
+$subscriptionId = $credentials.subscriptionId
+az rest --method DELETE `
+     --uri https://management.azure.com/subscriptions/$subscriptionId/resourceGroups/GitHubActions-RG/providers/Microsoft.DocumentDB/databaseAccounts/$cosmosName?api-version=2021-04-15"

--- a/cleanup.ps1
+++ b/cleanup.ps1
@@ -10,4 +10,4 @@ param (
 $credentials = $azureCredentials | ConvertFrom-Json
 $subscriptionId = $credentials.subscriptionId
 az rest --method DELETE `
-     --uri https://management.azure.com/subscriptions/$subscriptionId/resourceGroups/GitHubActions-RG/providers/Microsoft.DocumentDB/databaseAccounts/$cosmosName?api-version=2021-04-15"
+     --uri https://management.azure.com/subscriptions/$subscriptionId/resourceGroups/GitHubActions-RG/providers/Microsoft.DocumentDB/databaseAccounts/$cosmosName?api-version=2021-04-15

--- a/cleanup.ps1
+++ b/cleanup.ps1
@@ -7,5 +7,4 @@ param (
 #$ignore = az cosmosdb delete --resource-group GitHubActions-RG --name $cosmosName --yes
 
 # az rest method
-az rest --method DELETE \
-    --uri "https://management.azure.com/subscriptions/$($credentials.subscriptionId)/resourceGroups/GitHubActions-RG/providers/Microsoft.DocumentDB/databaseAccounts/$($cosmosName)?api-version=2021-04-15"
+az rest --method DELETE --uri "https://management.azure.com/subscriptions/$($credentials.subscriptionId)/resourceGroups/GitHubActions-RG/providers/Microsoft.DocumentDB/databaseAccounts/$($cosmosName)?api-version=2021-04-15"

--- a/cleanup.ps1
+++ b/cleanup.ps1
@@ -6,9 +6,6 @@ param (
 # Use this once cosmosdb delete offers --no-wait argument, until then, it takes too long (~7m) and we use curl instead
 #$ignore = az cosmosdb delete --resource-group GitHubActions-RG --name $cosmosName --yes
 
-# curl-based method
-$credentials = $azureCredentials | ConvertFrom-Json
-$token = curl -X POST -d "grant_type=client_credentials&client_id=$($credentials.clientId)&client_secret=$($credentials.clientSecret)&resource=https%3A%2F%2Fmanagement.azure.com%2F" https://login.microsoftonline.com/$($credentials.tenantId)/oauth2/token | ConvertFrom-Json
-$authHeader = "Authorization: Bearer $($token.access_token)"
-$resourceUrl = "https://management.azure.com/subscriptions/$($credentials.subscriptionId)/resourceGroups/GitHubActions-RG/providers/Microsoft.DocumentDB/databaseAccounts/$($cosmosName)?api-version=2021-04-15"
-curl -X DELETE $resourceUrl -H $authHeader -H "Content-Type: application/json" --silent
+# az rest method
+az rest --method DELETE \
+    --uri "https://management.azure.com/subscriptions/$($credentials.subscriptionId)/resourceGroups/GitHubActions-RG/providers/Microsoft.DocumentDB/databaseAccounts/$($cosmosName)?api-version=2021-04-15"


### PR DESCRIPTION
This uses AZ Rest which takes care of authentication automatically. Unfortunately we still need to pass the credentials to get the subscription ID but this seems to be already simpler overall. 

Should be squashed