### PR TITLE
Improve the reliability of the CosmosDB creation with sensible fallbacks

### DIFF
--- a/cleanup.ps1
+++ b/cleanup.ps1
@@ -5,11 +5,4 @@ param (
 
 $resourceGroup = $Env:RESOURCE_GROUP_OVERRIDE ?? "GitHubActions-RG"
 
-# Use this once cosmosdb delete offers --no-wait argument, until then, it takes too long (~7m) and we use curl instead
-#$ignore = az cosmosdb delete --resource-group GitHubActions-RG --name $cosmosName --yes
-
-# az rest method
-$credentials = $azureCredentials | ConvertFrom-Json
-$subscriptionId = $credentials.subscriptionId
-az rest --method DELETE `
-     --uri https://management.azure.com/subscriptions/$subscriptionId/resourceGroups/$($resourceGroup)/providers/Microsoft.DocumentDB/databaseAccounts/${cosmosName}?api-version=2021-04-15
+$ignore = az cosmosdb delete --resource-group $resourceGroup --name $cosmosName --yes --no-wait

--- a/setup.ps1
+++ b/setup.ps1
@@ -29,8 +29,8 @@ function Get-NearbyRegions {
   # If it's one of the common West/East forms, keep siblings first, then central-ish, then the opposite coast.
   if ($p -match '^westus(\d+)?$') {
     $siblings = @("westus","westus2","westus3","westcentralus") # west family first
-    $nearby   = @("southcentralus","centralus")                  # central next
-    $others   = @("eastus2","eastus","northcentralus")           # opposite side as last resort
+    $nearby   = @("southcentralus","centralus","northcentralus") # central family next
+    $others   = @("eastus2","eastus") # opposite coast last
     return @($primary) + $siblings + $nearby + $others
   }
   if ($p -match '^eastus(\d+)?$') {


### PR DESCRIPTION
This pull request introduces significant improvements to the CosmosDB setup and cleanup scripts, focusing on region selection logic, error handling, and resource management. The changes enhance the reliability of CosmosDB account creation by implementing a fallback mechanism for region selection and automating cleanup in case of capacity errors. Additionally, the scripts now use more robust and standardized Azure CLI commands for resource deletion.

**Region selection and fallback logic:**

* Added a new `Get-NearbyRegions` function to determine a prioritized list of fallback Azure regions based on the initially detected region, improving the chances of successful CosmosDB account provisioning. The script now filters available regions to US-only and attempts account creation in order of proximity and availability.
* Implemented a loop to try creating the CosmosDB account in each prioritized region, with error handling for capacity-related failures. If a region fails due to capacity, the script cleans up failed resources and tries the next region. Non-capacity errors halt further attempts.

**Resource cleanup improvements:**

* Updated the cleanup script to use the `az cosmosdb delete` command with the `--no-wait` flag for asynchronous resource deletion, replacing the previous workaround using `az rest`.

**Bug fixes and consistency:**

* Corrected variable name casing from `cosmosname` to `cosmosName` in CosmosDB table creation and key retrieval steps to ensure consistency and prevent errors.

**Error messaging and documentation:**

* Improved error messages and guidance for users encountering region capacity issues, including a link to the official Azure quota request page.